### PR TITLE
added new styling site component

### DIFF
--- a/src/components/StylingSite.tsx
+++ b/src/components/StylingSite.tsx
@@ -1,0 +1,68 @@
+import { useState } from "react";
+import Task from "./Task"
+import TaskList from "./TaskList"
+import MessageThread from "./MessageThread"
+
+const StylingSite: React.FC = () => {
+    const [activeComponent, setActiveComponent] = useState<string | null>(null);
+
+    const showTask = () => setActiveComponent("task");
+    const showTaskList = () => setActiveComponent("taskList");
+    const showMessageThread = () => setActiveComponent("messageThread");
+
+    return (
+        <div className="flex flex-col min-h-screen">
+            <header className="text-center my-10">
+                <h1 className="text-6xl font-semibold">Check me out 🥵!</h1>
+            </header>
+
+            <nav className="flex justify-center  space-x-4">
+                <button
+                    onClick={showTask}
+                    className="bg-slate-500 text-white px-8 py-2 rounded-full hover:bg-slate-700"
+                >
+                    List
+                </button>
+                <button
+                    onClick={showTaskList}
+                    className="bg-slate-500 text-white px-4 py-2 rounded-full hover:bg-slate-700"
+                >
+                    Task List
+                </button>
+                <button
+                    onClick={showMessageThread}
+                    className="bg-slate-500 text-white px-4 py-2 rounded-full hover:bg-slate-700"
+                >
+                    Message Thread
+                </button>
+            </nav>
+
+            <main className="flex-grow">
+                {activeComponent === "task" && (
+                    <section id="task" className="mb-10">
+                        <Task />
+                    </section>
+                )}
+
+                {activeComponent === "taskList" && (
+                    <section id="taskList" className="mb-10">
+                        <TaskList />
+                    </section>
+                )}
+
+                {activeComponent === "messageThread" && (
+                    <section id="messages" className="mb-10">
+                        <MessageThread />
+                    </section>
+                )}
+            </main>
+
+            {/* Footer */}
+            <footer className="text-center py-5 border-t mt-auto">
+                <p className="text-gray-600">© 2024 Faisal Owimer</p>
+            </footer>
+        </div>
+    );
+};
+
+export default StylingSite;

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -8,11 +8,12 @@ import "./index.css";
 import Task from "./components/Task";
 import TaskList from "./components/TaskList";
 import MessageThread from "./components/MessageThread";
+import StylingSite from "./components/StylingSite";
 
 const router = createBrowserRouter([
   {
     path: "/",
-    element: <div>Hello world!</div>,
+    element: <StylingSite />
   },
   {
     path: "/task",
@@ -28,7 +29,13 @@ const router = createBrowserRouter([
   },
 ]);
 
-ReactDOM.createRoot(document.getElementById("root")).render(
+const container = document.getElementById("root")
+
+if (!container) {
+  throw new Error("No root element.")
+}
+
+ReactDOM.createRoot(container).render(
   <React.StrictMode>
     <RouterProvider router={router} />
   </React.StrictMode>


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds `StylingSite` component to toggle between different views and integrates it as the root element in `main.tsx`.
> 
>   - **New Component**:
>     - Adds `StylingSite` component in `StylingSite.tsx` to toggle between `Task`, `TaskList`, and `MessageThread` components.
>     - Uses `useState` to manage active component state.
>   - **Integration**:
>     - Updates `main.tsx` to set `StylingSite` as the root element for the path `/`.
>     - Adds error handling for missing root element in `main.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=fractal-bootcamp%2Ffaisal-styling&utm_source=github&utm_medium=referral)<sup> for e22ca07e7fa7269bee212b6f03e8a9f111d80981. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->